### PR TITLE
Fix preshared key variables in variables.tf

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -127,7 +127,8 @@ variable "vpn_connection_tunnel1_phase2_dh_group_numbers" {
 variable "vpn_connection_tunnel1_preshared_key" {
   type        = string
   description = "The preshared key of the first VPN tunnel. The preshared key must be between 8 and 64 characters in length and cannot start with zero. Allowed characters are alphanumeric characters, periods(.) and underscores(_)"
-  default     = null
+  default     = ""
+  nullable    = false
 }
 
 variable "vpn_connection_tunnel1_startup_action" {
@@ -216,7 +217,8 @@ variable "vpn_connection_tunnel2_phase2_dh_group_numbers" {
 variable "vpn_connection_tunnel2_preshared_key" {
   type        = string
   description = "The preshared key of the second VPN tunnel. The preshared key must be between 8 and 64 characters in length and cannot start with zero. Allowed characters are alphanumeric characters, periods(.) and underscores(_)"
-  default     = null
+  default     = ""
+  nullable    = false
 }
 
 variable "vpn_connection_tunnel2_startup_action" {


### PR DESCRIPTION
## what
* Set variables for the preshared keys to be not nullable, as terraform doesn't allow to do `length(value)` on a null variable

## why
* to fix the component

## references
* closes #17 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the VPN connection setup so that preshared keys for both tunnels must be explicitly provided, ensuring more robust and consistent VPN configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->