### PR TITLE
chore: upgrade remote-state to v2.0.0

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.vpc_component_name
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 2.2"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from v1.x to v2.0.0
- This enables compatibility with `cloudposse/utils` provider v2.x
- Updates vendored account-map to standalone repo at v1.537.2

## Changes
- `src/remote-state.tf`: version pin `1.8.0`/`1.5.0` → `2.0.0`
- `src/versions.tf`: widen utils provider constraint (if applicable)
- `test/fixtures/vendor.yaml`: switch account-map to standalone repo (if applicable)

## Test plan
- [ ] CI lint passes (terraform init, no provider conflicts)
- [ ] Terratest passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)